### PR TITLE
Setup rust and refactor legacy code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,6 @@ members = [
 	"examples/*",
 	"crates/luminal_cpu",
 	"crates/luminal_nn",
-	"crates/luminal_training", "docs/company",
+	"crates/luminal_training",
 ]
-exclude = ["examples/yolo_v8", "crates/luminal_cuda", "crates/luminal_metal", "crates/luminal_2", "flash_attention_demo"]
+exclude = ["examples/yolo_v8", "crates/luminal_cuda", "crates/luminal_metal", "crates/luminal_2", "flash_attention_demo", "docs/company"]


### PR DESCRIPTION
Exclude `docs/company` from the workspace to streamline Rust compilation.

---

[Open in Web](https://cursor.com/agents?id=bc-4af0184c-8d62-4608-ab1d-f9d75ae54c5b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4af0184c-8d62-4608-ab1d-f9d75ae54c5b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)